### PR TITLE
41 refine aria label option

### DIFF
--- a/src/app/modules/wcag/components/wcag-list-filter/wcag-list-filter.component.ts
+++ b/src/app/modules/wcag/components/wcag-list-filter/wcag-list-filter.component.ts
@@ -20,19 +20,23 @@ export class WcagListFilterComponent extends BaseComponent implements OnInit {
 
 	readonly sortOptions: ISelectOptions = [
 		{
-			label: 'Order by Ids (ASC)',
+			label: 'Order by ID (asc)',
+			ariaLabel: 'Order by ID (ascending)',
 			value: WcagFilterSortOptions.BY_ID_ASC
 		},
 		{
-			label: 'Order by Ids (DESC)',
+			label: 'Order by ID (desc)',
+			ariaLabel: 'Order by ID (descending)',
 			value: WcagFilterSortOptions.BY_ID_DESC
 		},
 		{
-			label: 'Group By Levels (ASC)',
+			label: 'Group By Level (asc)',
+			ariaLabel: 'Group By Level (ascending)',
 			value: WcagFilterSortOptions.BY_LEVELS_ASC
 		},
 		{
-			label: 'Group By Levels (DESC)',
+			label: 'Group By Level (desc)',
+			ariaLabel: 'Group By Level (descending)',
 			value: WcagFilterSortOptions.BY_LEVELS_DESC
 		},
 	];

--- a/src/app/modules/wcag/pages/wcag-item/wcag-item.component.ts
+++ b/src/app/modules/wcag/pages/wcag-item/wcag-item.component.ts
@@ -4,6 +4,7 @@ import {PageTitleService} from '../../../../core/services/page-title.service';
 import {ActivatedRoute, Data} from '@angular/router';
 import {IWCAGItem} from '../../../../shared/interfaces/wcag-item';
 import {takeUntil} from 'rxjs/operators';
+import {SkipLinksService} from '../../../../core/services/skip-links.service';
 
 @Component({
   selector: 'app-wcag-item',
@@ -16,9 +17,10 @@ export class WcagItemComponent extends BasePageComponent implements OnInit {
 
 	constructor(
 		protected pageTitleService: PageTitleService,
+		protected skipLinksService: SkipLinksService,
 		private route: ActivatedRoute,
 	) {
-		super(pageTitleService);
+		super(pageTitleService, skipLinksService);
 	}
 
 	ngOnInit() {

--- a/src/app/shared/components/a11y-select/a11y-select.component.html
+++ b/src/app/shared/components/a11y-select/a11y-select.component.html
@@ -18,11 +18,13 @@
 					*ngIf="!isOptionGroup(option)"
 					[value]="option.value"
 					[selected]="!!selectedOption && selectedOption.value == option.value"
+					[attr.aria-label]="!!option.ariaLabel ? option.ariaLabel : null"
 				>
 					{{ option.label }}
 				</option>
 				<optgroup
 					*ngIf="isOptionGroup(option)"
+					[attr.aria-label]="!!option.ariaLabel ? option.ariaLabel : null"
 					[label]="option.label"
 				>
 					<option


### PR DESCRIPTION
- Sort works with VO+Chrome
- After being select, aria-label gets read out
- When navigating through the options, aria-label does not get read out
- Landing on the select, the aria-label gets read out.
- Keeping it in. Hoping that VO and other SR would get updated to accommodate. Or the browsers